### PR TITLE
Enclose preview code inside if debug clause

### DIFF
--- a/Sources/DynamicList/DynamicListView.swift
+++ b/Sources/DynamicList/DynamicListView.swift
@@ -114,6 +114,7 @@ public struct DynamicListView<Item: Identifiable>: View {
     }
 }
 
+#if DEBUG
 struct DynamicListView_Previews: PreviewProvider {
     static var previews: some View {
         DynamicListViewComposer.compose(
@@ -162,3 +163,4 @@ struct DynamicListView_Previews: PreviewProvider {
         }
     }
 }
+#endif

--- a/Sources/DynamicList/Views/FloatingActionButtonView.swift
+++ b/Sources/DynamicList/Views/FloatingActionButtonView.swift
@@ -42,8 +42,10 @@ struct FloatingActionButtonView: View {
     }
 }
 
+#if DEBUG
 struct FloatingActionButtonView_Previews: PreviewProvider {
     static var previews: some View {
         FloatingActionButtonView(action: {})
     }
 }
+#endif

--- a/Sources/DynamicList/Views/ListItemView.swift
+++ b/Sources/DynamicList/Views/ListItemView.swift
@@ -41,6 +41,7 @@ struct ListItemView<Item>: View {
     }
 }
 
+#if DEBUG
 struct ListItemView_Previews: PreviewProvider {
     static let fruitA = Fruit(name: "Plátano", symbol: "🍌", color: .yellow)
     static let fruitB = Fruit(name: "Manzana", symbol: "🍎", color: .red)
@@ -70,3 +71,4 @@ struct ListItemView_Previews: PreviewProvider {
         }
     }
 }
+#endif

--- a/Sources/DynamicList/Views/LoadingErrorView.swift
+++ b/Sources/DynamicList/Views/LoadingErrorView.swift
@@ -26,8 +26,10 @@ public struct LoadingErrorView: View {
     }
 }
 
+#if DEBUG
 struct LoadingErrorView_Previews: PreviewProvider {
     static var previews: some View {
         LoadingErrorView()
     }
 }
+#endif

--- a/Sources/DynamicList/Views/NoItemsView.swift
+++ b/Sources/DynamicList/Views/NoItemsView.swift
@@ -25,8 +25,10 @@ public struct NoItemsView: View {
     }
 }
 
+#if DEBUG
 struct NoItemsView_Previews: PreviewProvider {
     static var previews: some View {
         NoItemsView()
     }
 }
+#endif

--- a/Sources/DynamicList/Views/TopicSegmentedView.swift
+++ b/Sources/DynamicList/Views/TopicSegmentedView.swift
@@ -21,6 +21,7 @@ struct TopicSegmentedView: View {
     }
 }
 
+#if DEBUG
 struct TopicSegmentedView_Previews: PreviewProvider {
     static var previews: some View {
         TopicSegmentedView(
@@ -29,3 +30,4 @@ struct TopicSegmentedView_Previews: PreviewProvider {
         )
     }
 }
+#endif


### PR DESCRIPTION
When generate a release build, the preview code is searching for the development code (enclosed by the IF DEBUG sentences).
This PR encapsule the code inside a IF DEBUG sentence that is only used for SwiftUI previews to avoid search preview code on release builds.