### PR TITLE
fix: Add `debounce` to search query to avoid multiple calls to the loader

### DIFF
--- a/Sources/DynamicList/DynamicListView.swift
+++ b/Sources/DynamicList/DynamicListView.swift
@@ -58,7 +58,6 @@ public struct DynamicListView<Item: Identifiable>: View {
                             prompt: Text(DynamicListPresenter.search),
                             display: store.searchingByQuery != nil
                         )
-                        .onChange(of: store.query, perform: { _ in loadItems() })
                         .overlay(Group {
                             if let items = store.sections.first?.items, items.isEmpty, store.error == nil {
                                 withAnimation(.easeIn) {

--- a/Sources/DynamicList/Preview Helpers/FruitsLoader.swift
+++ b/Sources/DynamicList/Preview Helpers/FruitsLoader.swift
@@ -43,6 +43,8 @@ func testFruitsLoader() -> AnyPublisher<[AnyIdentifiable], Error> {
     fruitsLoader.map { fruits in
         fruits.map { AnyIdentifiable(id: $0.id, value: $0) }
     }
+    .subscribe(on: DispatchQueue.global(qos: .userInitiated))
+    .receive(on: DispatchQueue.main)
     .delay(for: .seconds(0.3), scheduler: DispatchQueue.main)
     .eraseToAnyPublisher()
 }

--- a/Tests/DynamicListTests/DynamicListViewStoreTests.swift
+++ b/Tests/DynamicListTests/DynamicListViewStoreTests.swift
@@ -125,6 +125,21 @@ final class DynamicListViewStoreTests: XCTestCase {
 
         XCTAssertEqual(sut.sections.first?.items, ["abcd", "dcba", "abba"])
     }
+    
+    func test_searchByQuery_requestLoadItems() {
+        let loader = LoaderSpy<String>()
+        let sut = DynamicListViewStore<String>(
+            searchingByQuery: { query, item in
+                query == "" ? true : item.range(of: query, options: [.diacriticInsensitive, .caseInsensitive]) != nil
+            },
+            loader: loader.publisher,
+            testingMode: true
+        )
+        XCTAssertEqual(loader.loadCallCount, 0)
+
+        sut.query = "o"
+        XCTAssertEqual(loader.loadCallCount, 1)
+    }
 
     func test_searchByQuery_returnsItemsSearchingByQuery() async {
         let items = ["home", "office", "test", "todo", "fix"]
@@ -133,14 +148,13 @@ final class DynamicListViewStoreTests: XCTestCase {
             searchingByQuery: { query, item in
                 query == "" ? true : item.range(of: query, options: [.diacriticInsensitive, .caseInsensitive]) != nil
             },
-            loader: loader.publisher
+            loader: loader.publisher,
+            testingMode: true
         )
-
+        
         sut.query = "o"
-        await sut.loadItemsAsync {
-            loader.complete(with: items, at: 0)
-        }
-
+        loader.complete(with: items, at: 0)
+        
         XCTAssertEqual(sut.sections.first?.items, ["home", "office", "todo"])
     }
 
@@ -149,13 +163,12 @@ final class DynamicListViewStoreTests: XCTestCase {
         let loader = LoaderSpy<String>()
         let sut = DynamicListViewStore<String>(
             searchingByQuery: nil,
-            loader: loader.publisher
+            loader: loader.publisher,
+            testingMode: true
         )
 
         sut.query = "any query"
-        await sut.loadItemsAsync {
-            loader.complete(with: items, at: 0)
-        }
+        loader.complete(with: items, at: 0)
 
         XCTAssertEqual(sut.sections.first?.items, items)
     }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The UI is freezed when multiple api calls are requested through the loader. This PR fixes the bug

Before:

https://github.com/AlfredoHernandez/DynamicList/assets/22734433/c8fafe54-f61d-4d27-b99c-bbc0d83dca17

After:

https://github.com/AlfredoHernandez/DynamicList/assets/22734433/f70b434e-6cbc-4ecf-9cf3-982a3c0e4b03