### PR TITLE
fix: Update from background threads

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/DynamicList.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/DynamicList.xcscheme
@@ -64,6 +64,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableThreadSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/.swiftpm/xcode/xcshareddata/xcschemes/DynamicList.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/DynamicList.xcscheme
@@ -64,7 +64,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      enableThreadSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Sources/DynamicList/Preview Helpers/FruitsLoader.swift
+++ b/Sources/DynamicList/Preview Helpers/FruitsLoader.swift
@@ -43,7 +43,7 @@ func testFruitsLoader() -> AnyPublisher<[AnyIdentifiable], Error> {
     fruitsLoader.map { fruits in
         fruits.map { AnyIdentifiable(id: $0.id, value: $0) }
     }
-    .subscribe(on: DispatchQueue.global(qos: .userInitiated))
+    .subscribe(on: DispatchQueue.global(qos: .background))
     .receive(on: DispatchQueue.main)
     .delay(for: .seconds(0.3), scheduler: DispatchQueue.main)
     .eraseToAnyPublisher()

--- a/Tests/DynamicListTests/DynamicListViewStoreTests.swift
+++ b/Tests/DynamicListTests/DynamicListViewStoreTests.swift
@@ -154,7 +154,7 @@ final class DynamicListViewStoreTests: XCTestCase {
         
         sut.query = "o"
         loader.complete(with: items, at: 0)
-        
+
         XCTAssertEqual(sut.sections.first?.items, ["home", "office", "todo"])
     }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

At the moment to load/refresh the list of items, list was updated from a background thread due the async/await adapter with the loader (a combine publisher). This PR fixes the issue.

